### PR TITLE
Fixed player moving during a fatality and saw attack fix

### DIFF
--- a/actors/Weapons/Slot1/MELEE.dec
+++ b/actors/Weapons/Slot1/MELEE.dec
@@ -272,7 +272,14 @@ ACTOR Melee_Attacks : PB_Weapon Replaces Fist
 		TNT1 A 0 A_PlaySoundEx("weapons/fists_up", "Auto")
 		P9NS EFGHITUVW 1 
 	ReadyFists:
-		TNT1 A 0 SetPlayerProperty(0,0,0)
+		TNT1 A 0 {
+			if(CountInv("GoFatality") >= 1) {
+				SetPlayerProperty(0,1,0);
+			}	
+			else {
+				SetPlayerProperty(0,0,0);
+			}
+		}
 		TNT1 A 0 A_Overlay(-10, "FirstPersonLegsStand")
     Ready3:
 		TNT1 A 0 A_SetRoll(0)

--- a/actors/Weapons/Slot1/SAW.dec
+++ b/actors/Weapons/Slot1/SAW.dec
@@ -555,9 +555,14 @@ Actor Chain_saw : PB_Weapon replaces Chainsaw
 					A_TakeInventory("PowerBlueBloodOnVisor",1);
 				}
 			}
-		"####" A 2 A_Refire("RightAttackClean2")
-		"####" A 0 A_Playsound("CSAWSTAT", 7)
-		"####" NOPQ 1 A_FireCustomMissile("GunFireSmoke", 0, 0, -5, -5, 0, 0)
+		TNT1 A 2 A_Refire("RightAttackClean2")
+		TNT1 A 0 A_Playsound("CSAWSTAT", 7)
+		C4S1 NOPQ 1 {
+				A_FireCustomMissile("GunFireSmoke", 0, 0, -5, -5, 0, 0);
+				if (CountInv("PowerGreenBloodOnVisor") == 1) { A_SetWeaponSprite("C4S4"); }
+				if (CountInv("PowerBlueBloodOnVisor") == 1) { A_SetWeaponSprite("C4S3"); }
+				if (CountInv("PowerBloodOnVisor") == 1) { A_SetWeaponSprite("C4S2"); }
+			}
 		SAWG A 0 {
 				if (CountInv("PowerGreenBloodOnVisor") == 1) { A_SetWeaponSprite("SAW4"); }
 				if (CountInv("PowerBlueBloodOnVisor") == 1) { A_SetWeaponSprite("SAW3"); }
@@ -621,9 +626,14 @@ Actor Chain_saw : PB_Weapon replaces Chainsaw
 					A_TakeInventory("PowerBlueBloodOnVisor",1);
 				}
 			}
-		"####" A 2 A_Refire("RightAttackClean")
-		"####" A 0 A_Playsound("CSAWSTAT", 7)
-		"####" RSTU 1 A_FireCustomMissile("GunFireSmoke", 0, 0, -5, -5, 0, 0)
+		TNT1 A 2 A_Refire("RightAttackClean")
+		TNT1 A 0 A_Playsound("CSAWSTAT", 7)
+		C4S1 RSTU 1 {
+				A_FireCustomMissile("GunFireSmoke", 0, 0, -5, -5, 0, 0);
+				if (CountInv("PowerGreenBloodOnVisor") == 1) { A_SetWeaponSprite("C4S4"); }
+				if (CountInv("PowerBlueBloodOnVisor") == 1) { A_SetWeaponSprite("C4S3"); }
+				if (CountInv("PowerBloodOnVisor") == 1) { A_SetWeaponSprite("C4S2"); }
+			}
 		SAWG A 0 {
 				if (CountInv("PowerGreenBloodOnVisor") == 1) { A_SetWeaponSprite("SAW4"); }
 				if (CountInv("PowerBlueBloodOnVisor") == 1) { A_SetWeaponSprite("SAW3"); }
@@ -689,8 +699,8 @@ Actor Chain_saw : PB_Weapon replaces Chainsaw
 					A_TakeInventory("PowerBlueBloodOnVisor",1);
 				}
 			}
-		"####" A 1 A_Refire("LeftAttackClean2")
-		"####" A 0 A_Playsound("CSAWSTAT", 7)
+		TNT1 A 1 A_Refire("LeftAttackClean2")
+		TNT1 A 0 A_Playsound("CSAWSTAT", 7)
 		C4S1 RSTU 1 {
 			A_FireCustomMissile("GunFireSmoke", 0, 0, -5, -5, 0, 0);
 			if (CountInv("PowerGreenBloodOnVisor") == 1) { A_SetWeaponSprite("C4S4"); }
@@ -761,8 +771,8 @@ Actor Chain_saw : PB_Weapon replaces Chainsaw
 					A_TakeInventory("PowerBlueBloodOnVisor",1);
 				}
 			}
-		"####" A 1 A_Refire("LeftAttackClean")
-		"####" A 0 A_Playsound("CSAWSTAT", 7)
+		TNT1 A 1 A_Refire("LeftAttackClean")
+		TNT1 A 0 A_Playsound("CSAWSTAT", 7)
 		C4S1 NOPQ 1 {
 			A_FireCustomMissile("GunFireSmoke", 0, 0, -5, -5, 0, 0);
 			if (CountInv("PowerGreenBloodOnVisor") == 1) { A_SetWeaponSprite("C4S4"); }


### PR DESCRIPTION
Fixed the player being able to move while performing a fatality. All I did was add an if else statement when the GoFatality token is initiated under the ReadyFists state.

New update: Fixed left and right attack finished states from looking strange